### PR TITLE
17 update files needs to check input format

### DIFF
--- a/src/roman_hlis_l2_driver/name_util.py
+++ b/src/roman_hlis_l2_driver/name_util.py
@@ -1,6 +1,7 @@
 """
 Utilities for file names and formats.
 """
+import numpy as np
 
 
 def stem_l2(file_format, filter):
@@ -47,7 +48,12 @@ def stem_mask(file_format):
     """
 
     if file_format == "L2_2506":
-        return f"_mask.fits"
+
+        tail = "_mask.fits"
+        hdu = "MASK"
+        bits = np.uint8(1)
+        return tail, hdu, bits
+    
     else:
         print("Please add the new format to name_util.")
         raise ValueError(f"unsupported format in name_util: {file_format}")

--- a/src/roman_hlis_l2_driver/name_util.py
+++ b/src/roman_hlis_l2_driver/name_util.py
@@ -5,7 +5,7 @@ Utilities for file names and formats.
 
 def stem_l2(file_format, filter):
     """
-    Utility to return the stem format for an L2 file.
+    Utility to return the stem format for a JWST file.
 
     Paramters
     ---------
@@ -23,6 +23,31 @@ def stem_l2(file_format, filter):
 
     if file_format == "L2_2506":
         return f"/sim_L2_{filter:s}"
+    else:
+        print("Please add the new format to name_util.")
+        raise ValueError(f"unsupported format in name_util: {file_format}")
+
+
+def stem_mask(file_format):
+    """
+    Utility to return the stem format for a mask file.
+
+    Paramters
+    ---------
+    file_format : str
+        The format type (same as used in PyIMCOM).
+    filter : str
+        The 4-character filter code.
+
+    Returns
+    -------
+    str
+        A string to append to a directory to get the stem.
+
+    """
+
+    if file_format == "L2_2506":
+        return f"_mask.fits"
     else:
         print("Please add the new format to name_util.")
         raise ValueError(f"unsupported format in name_util: {file_format}")

--- a/src/roman_hlis_l2_driver/name_util.py
+++ b/src/roman_hlis_l2_driver/name_util.py
@@ -6,7 +6,7 @@ import numpy as np
 
 def stem_l2(file_format, filter):
     """
-    Utility to return the stem format for a JWST file.
+    Utility to return the stem format for an L2 file.
 
     Paramters
     ---------

--- a/src/roman_hlis_l2_driver/name_util.py
+++ b/src/roman_hlis_l2_driver/name_util.py
@@ -48,12 +48,11 @@ def stem_mask(file_format):
     """
 
     if file_format == "L2_2506":
-
         tail = "_mask.fits"
         hdu = "MASK"
         bits = np.uint8(1)
         return tail, hdu, bits
-    
+
     else:
         print("Please add the new format to name_util.")
         raise ValueError(f"unsupported format in name_util: {file_format}")

--- a/src/roman_hlis_l2_driver/outliers/outlier_flagging.py
+++ b/src/roman_hlis_l2_driver/outliers/outlier_flagging.py
@@ -227,9 +227,8 @@ class OutlierMap:
             if len(self.files) == max_files:
                 break
         self.n_obs = len(self.files)
-        self.fformat = file_format
-
         print(self.n_obs)
+        self.fformat = file_format
 
         # image arrays
         self.image = np.zeros((self.n_obs, Stn.sca_nside, Stn.sca_nside), dtype=np.float32)

--- a/src/roman_hlis_l2_driver/outliers/outlier_flagging.py
+++ b/src/roman_hlis_l2_driver/outliers/outlier_flagging.py
@@ -16,7 +16,7 @@ from scipy.interpolate import RegularGridInterpolator
 from scipy.ndimage import maximum_filter
 from scipy.signal import convolve2d
 
-from ..name_util import stem_l2
+from ..name_util import stem_l2, stem_mask
 
 
 def _load_img_wcs(arg):
@@ -96,7 +96,7 @@ def _blot_mask(arr):
     arr[:, :] = arr2
 
 
-def update_files(info, verbose=False):
+def update_files(info, file_format, verbose=False):
     """
     Updates the mask information in the targeted files.
 
@@ -110,6 +110,9 @@ def update_files(info, verbose=False):
         - ``files`` : list of str; the files to be updated.
 
         - ``mask`` : np.ndarray of bool; the additional pixels to mask
+
+    file_format : str
+        The format type (same as used in PyIMCOM).
 
     verbose : bool, optional
         Talk to the output.
@@ -129,6 +132,8 @@ def update_files(info, verbose=False):
     """
 
     N = len(info["files"])
+    tail, hdu, _ = stem_mask(file_format)
+
     for j in range(N):
         fj = info["files"][j]
         if verbose:
@@ -138,9 +143,9 @@ def update_files(info, verbose=False):
             mytree = a.tree
         if "mask" not in mytree:
             mytree["mask"] = np.zeros((Stn.sca_nside, Stn.sca_nside), dtype=np.uint8)
-        with fits.open(fj[:-5] + "_mask.fits") as f:
+        with fits.open(fj[:-5] + tail) as f:
             mytree["mask"] &= ~np.uint8(3)
-            mytree["mask"] |= np.where(f["MASK"].data > 0, 1, 0).astype(np.uint8)
+            mytree["mask"] |= np.where(f[hdu].data > 0, 1, 0).astype(np.uint8)
         mytree["mask"] |= info["mask"][j, :, :].astype(np.uint8) << 1
         mytree["processinfo"]["outlier_complete"] = True
         asdf.AsdfFile(mytree).write_to(fj)
@@ -222,6 +227,7 @@ class OutlierMap:
             if len(self.files) == max_files:
                 break
         self.n_obs = len(self.files)
+        self.fformat = file_format
 
         print(self.n_obs)
 
@@ -238,13 +244,7 @@ class OutlierMap:
         sys.stdout.flush()
 
         # mask
-        if file_format == "L2_2506":
-            tail = "_mask.fits"
-            hdu = "MASK"
-            bits = np.uint8(1)
-        else:
-            print("Please add the new format to outlier_flagging.")
-            raise ValueError(f"unsupported format in outlier_flagging: {file_format}")
+        tail, hdu, bits = stem_mask(file_format)
         self.maskfiles = [f[:-5] + tail for f in self.files]
         self.mask = np.zeros((self.n_obs, Stn.sca_nside, Stn.sca_nside), dtype=bool)
         with ThreadPoolExecutor(max_workers=max_workers) as e:
@@ -550,7 +550,7 @@ class OutlierMap:
         asdf.AsdfFile(tree).write_to(outfile)
 
         if update:
-            update_files(tree, verbose=verbose)
+            update_files(tree, self.fformat, verbose=verbose)
 
 
 # this stuff will eventually be moved to another script

--- a/tests/roman_hlis_l2_driver/test_stem.py
+++ b/tests/roman_hlis_l2_driver/test_stem.py
@@ -1,7 +1,7 @@
 """Test for file name utilities."""
 
 import pytest
-from roman_hlis_l2_driver.name_util import stem_l2
+from roman_hlis_l2_driver.name_util import stem_l2, stem_mask
 
 
 def test_stem():
@@ -12,3 +12,15 @@ def test_stem():
 
     with pytest.raises(ValueError):
         stem_l2("undefined_format", "J129")
+
+
+def test_stem_mask():
+    """Test the stem_mask function."""
+
+    tail, hdu, bits = stem_mask("L2_2506")
+    assert tail == "_mask.fits"
+    assert hdu == "MASK"
+    assert bits == 1
+
+    with pytest.raises(ValueError):
+        stem_mask("undefined_format")


### PR DESCRIPTION
Change the way masks are accessed to check input format before trying to read files.

Updates:
1. name_util.py now has a function stem_mask that takes the PyIMCOM file format as input and returns the mask stem, the hdu of the mask, and a bit size . It also raises an error if the provided file format is not explicitly defined in this function yet.
2. Inside outlier_flagging.py, masks are read by passing the file format to name_util.stem_mask to get the proper stem, hdu, and bits and then they can be read using the returned values. This is applied both inside the update_files function and in the init method of OutlierMapping.