### PR TITLE
allow general pyimcom

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ galsim
 fitsio
 asdf
 roman_datamodels
-pyimcom @ git+https://github.com/Roman-HLIS-Cosmology-PIT/pyimcom
+pyimcom


### PR DESCRIPTION
Removed specific versioning for pyimcom dependency.

Now that `pyimcom` is on PyPI, pointing to main isn't needed anymore.