### PR TITLE
ffov now gets median read noise from an internal list

### DIFF
--- a/src/roman_hlis_l2_driver/fullfovexport/fullfov.py
+++ b/src/roman_hlis_l2_driver/fullfovexport/fullfov.py
@@ -20,6 +20,30 @@ from roman_datamodels.dqflags import pixel
 
 from .. import pars
 
+PER_SCA_CDS_NOISE = np.array(
+    [
+        17.49,
+        14.20,
+        14.70,
+        15.76,
+        13.64,
+        13.65,
+        13.21,
+        12.49,
+        12.39,
+        15.75,
+        13.94,
+        13.73,
+        16.17,
+        13.46,
+        13.46,
+        13.49,
+        12.64,
+        12.42,
+    ],
+    dtype=np.float32,
+)  # CDS noise in electrons from roman-technical-information
+
 
 def get_t_eff(K, tau, tbar):
     """
@@ -147,7 +171,16 @@ class FullFoVImage:
 
                     # get gain information
                     eqvgain = dslope * t_eff * medgain
-                    bkgndvar1 = np.median(a["roman"]["var_rnoise"]) / dslope**2
+                    # old calculation
+                    # bkgndvar1 = np.median(a["roman"]["var_rnoise"]) / dslope**2
+                    # new version without referring to the read noise frame, in (DN/s)^2
+                    n_frame_in_group = np.array([len(_x) for _x in pmeta["read_pattern"]])
+                    bkgndvar1 = (
+                        (PER_SCA_CDS_NOISE[sca - 1] / medgain) ** 2
+                        / 2.0
+                        * np.sum(pmeta["K"] ** 2 / n_frame_in_group)
+                        / dslope**2
+                    )
                     bkgndvar2 = a["processinfo"]["medsky"] / (t_eff * medgain * dslope**2)
 
             except FileNotFoundError:


### PR DESCRIPTION
Resolves #39.

The read noise term now comes from an internal table of the median CDS noise for each SCA, and is rescaled based on the read pattern.

In the future I might try to pass some additional information from romanimpreprocess and have roman-hlis-l2-driver look for that with the table as a fallback if it's not present. But this solution should work for the E2E test, and probably early flight data as well.